### PR TITLE
Fix to make Day rows more prominent

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2276,3 +2276,20 @@ body .yc {
     margin-top: -22px;
     margin-left: 223px;
 }
+.H {
+    background-color: teal;
+    height: 45px;
+}
+
+.H .Nb, .H .Ob {
+  border-top-width: 0;
+}
+
+.H .db {
+	color: white;
+	font-size: larger;
+}
+
+.H .p {
+	width: 0px;
+}


### PR DESCRIPTION
Attempt to bring the original styling back for Day rows when ordered by day with 4 additional CSS selectors at end of file